### PR TITLE
Minor fix of SRL zMIPS instruction type

### DIFF
--- a/src/main/java/org/twc/zerojavacompiler/kanga2zmips/Kanga2zMIPS.java
+++ b/src/main/java/org/twc/zerojavacompiler/kanga2zmips/Kanga2zMIPS.java
@@ -381,7 +381,7 @@ public class Kanga2zMIPS extends GJNoArguDepthFirst<String> {
         String[] retValue = {
                 "slt", "sle", "seq", "sne",         // comparison
                 "add", "sub", "mult", "div", "mod", // arithmetic
-                "and", "or", "xor", "sll", "slr"    // bitwise
+                "and", "or", "xor", "sll", "srl"    // bitwise
         };
         return retValue[n.f0.which];
     }


### PR DESCRIPTION
was accidentally `slr` which generated unparseable zMIPS code.